### PR TITLE
Supports ISO 8601 basic format

### DIFF
--- a/isodate.js
+++ b/isodate.js
@@ -5,7 +5,7 @@ module.exports = function (string) {
     var match;
 	if (typeof string.getTime === "function")
 		return string;
-	else if (match = string.match(/^(\d{4})(-(\d{2})(-(\d{2})(T(\d{2}):(\d{2})(:(\d{2})(\.(\d+))?)?(Z|((\+|-)(\d{2}):(\d{2}))))?)?)?$/)) {
+	else if (match = string.match(/^(\d{4})(-?(\d{2})(-?(\d{2})(T(\d{2}):?(\d{2})(:?(\d{2})(\.(\d+))?)?(Z|((\+|-)(\d{2}):?(\d{2}))))?)?)?$/)) {
 		var date = new Date();
 		date.setUTCFullYear(Number(match[1]));
 		date.setUTCMonth(Number(match[3]) - 1 || 0);

--- a/test.js
+++ b/test.js
@@ -5,6 +5,11 @@ var datestring = "2011-08-18T19:03:37+01:00";
 console.log("Parsing: " + datestring);
 console.log("Result: " + ISODate(datestring) + "\n");
 
+// Parse ISO date string without delimiters
+var datestring = "20110818T190337+0100";
+console.log("Parsing: " + datestring);
+console.log("Result: " + ISODate(datestring) + "\n");
+
 // Writing current time
 console.log("Parsing current time.");
 var date = new Date();


### PR DESCRIPTION
The ISO 8601 spec includes a "basic format" which does not have delimiters. Example: 20080915T155300+0500. This patch lets isodate support that format.
